### PR TITLE
Change remote repo public url

### DIFF
--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -31,8 +31,8 @@ jobs:
         run: ./scripts/publish_plugins_remote.sh
         env:
           REMOTE_REPO_PUBLIC_URL: ${{ secrets.REMOTE_REPO_PUBLIC_URL }}
-          REMOTE_REPO_PUBLIC_USER: ${{ secrets.ARTIFACTORY_PUBLIC_USER }}
-          REMOTE_REPO_PUBLIC_PASSWORD: ${{ secrets.ARTIFACTORY_PUBLIC_PASSWORD }}
+          REMOTE_REPO_PUBLIC_USER: ${{ secrets.REMOTE_REPO_PUBLIC_USER }}
+          REMOTE_REPO_PUBLIC_PASSWORD: ${{ secrets.REMOTE_REPO_PUBLIC_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/publish_rules.yml
+++ b/.github/workflows/publish_rules.yml
@@ -29,8 +29,8 @@ jobs:
         run: ./scripts/publish_rules_remote.sh
         env:
           REMOTE_REPO_PUBLIC_URL: ${{ secrets.REMOTE_REPO_PUBLIC_URL }}
-          REMOTE_REPO_PUBLIC_USER: ${{ secrets.ARTIFACTORY_PUBLIC_USER }}
-          REMOTE_REPO_PUBLIC_PASSWORD: ${{ secrets.ARTIFACTORY_PUBLIC_PASSWORD }}
+          REMOTE_REPO_PUBLIC_USER: ${{ secrets.REMOTE_REPO_PUBLIC_USER }}
+          REMOTE_REPO_PUBLIC_PASSWORD: ${{ secrets.REMOTE_REPO_PUBLIC_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}


### PR DESCRIPTION
в связи с переездом maven https://central.sonatype.org/news/20250326_ossrh_sunset/
Публикация переведена в https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/

изменены переменные:
REMOTE_REPO_PUBLIC_PASSWORD
REMOTE_REPO_PUBLIC_URL
REMOTE_REPO_PUBLIC_USER